### PR TITLE
Feature/464324 Updated run date logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,23 @@ To run locally, create a file `local.settings.json`. This file is in `.gitignore
 {
     "IsEncrypted": false,
     "Values": {
-		"AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
         "CommonDataApi__BaseUrl": "",
         "CommonDataApi__SubmissionsEndPoint": "api/submissions/v1/pom/approved/",
+        "CommonDataApi__LogPrefix": "[EPR.PRN.ObligationCalulation]",
+        "CommonBackendApi__LogPrefix": "[EPR.PRN.ObligationCalulation]",
         "CommonBackendApi__BaseUrl": "",
         "CommonBackendApi__PrnCalculateEndPoint": "api/v1/prn/organisation/{0}/calculate",
-        "ServiceBus__Namespace": "",
+        "ServiceBus__FullyQualifiedNamespace": "",
         "ServiceBus__ObligationQueueName": "",
         "ServiceBus__ObligationLastSuccessfulRunQueueName": "",
         "ServiceBus__ConnectionString": "",
+        "ServiceBus__LogPrefix": "[EPR.PRN.ObligationCalulation]",
+        "ApplicationConfig__LogPrefix": "[EPR.PRN.ObligationCalulation]",
         "ApplicationConfig__DeveloperMode": true,
-        "ApplicationConfig__UseDefaultRunDate": true,
         "ApplicationConfig__DefaultRunDate": "2024-01-01",
-        "StoreApprovedSubmissions__Schedule": "0 */30 * * * *"
+        "StoreApprovedSubmissions__Schedule": "0/30 * * * * *"
     }
 }
 ```

--- a/src/EPR.PRN.ObligationCalculation.Application/Configs/ApplicationConfig.cs
+++ b/src/EPR.PRN.ObligationCalculation.Application/Configs/ApplicationConfig.cs
@@ -7,7 +7,6 @@ public class ApplicationConfig
 {
     public const string SectionName = "ApplicationConfig";
     public bool DeveloperMode { get; set; }
-    public bool UseDefaultRunDate { get; set; }
     public string DefaultRunDate { get; set; } = null!;
     public string LogPrefix { get; set; } = string.Empty;
 }

--- a/src/EPR.PRN.ObligationCalculation.Application/Services/SubmissionsDataService.cs
+++ b/src/EPR.PRN.ObligationCalculation.Application/Services/SubmissionsDataService.cs
@@ -3,7 +3,6 @@ using EPR.PRN.ObligationCalculation.Application.DTOs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using System.Net;
 
 namespace EPR.PRN.ObligationCalculation.Application.Services;
 

--- a/src/EPR.PRN.ObligationCalculation.Function.UnitTests/ProcessApprovedSubmissionsFunctionTests.cs
+++ b/src/EPR.PRN.ObligationCalculation.Function.UnitTests/ProcessApprovedSubmissionsFunctionTests.cs
@@ -25,7 +25,6 @@ public class ProcessApprovedSubmissionsFunctionTests
         _configMock = new Mock<IOptions<ApplicationConfig>>();
         var config = new ApplicationConfig
         {
-            UseDefaultRunDate = false,
             DefaultRunDate = "2024-01-01"
         };
 

--- a/src/EPR.PRN.ObligationCalculation.Function.UnitTests/StoreApprovedSubmissionsFunctionTests.cs
+++ b/src/EPR.PRN.ObligationCalculation.Function.UnitTests/StoreApprovedSubmissionsFunctionTests.cs
@@ -63,8 +63,6 @@ public class StoreApprovedSubmissionsFunctionTests
             It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Exactly(logInformationCount));
     }
 
-
-
     [TestMethod]
     [DataRow(null)]
     [DataRow("")]
@@ -90,7 +88,6 @@ public class StoreApprovedSubmissionsFunctionTests
             It.IsAny<It.IsAnyType>(),
             It.IsAny<Exception>(),
             It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Exactly(1));
-
     }
 
     [TestMethod]

--- a/src/EPR.PRN.ObligationCalculation.Function/StoreApprovedSubmissionsFunction.cs
+++ b/src/EPR.PRN.ObligationCalculation.Function/StoreApprovedSubmissionsFunction.cs
@@ -20,6 +20,12 @@ public class StoreApprovedSubmissionsFunction(ILogger<StoreApprovedSubmissionsFu
             logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Last run date {Date} retrieved from queue", config.Value.LogPrefix, lastSuccessfulRunDateFromQueue);
 
             var lastSuccessfulRunDate = string.IsNullOrEmpty(lastSuccessfulRunDateFromQueue) ? config.Value.DefaultRunDate : lastSuccessfulRunDateFromQueue;
+            
+            if (string.IsNullOrEmpty(lastSuccessfulRunDate))
+            {
+                logger.LogError("{LogPrefix}: StoreApprovedSubmissionsFunction: Last succesful run date is empty and function is terminated", config.Value.LogPrefix);
+                return;
+            }
 
             var approvedSubmissionEntities = await submissionsService.GetApprovedSubmissionsData(lastSuccessfulRunDate);
             logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Approved submission entities retrieved from backnend {ApprovedSubmissionEntities}", config.Value.LogPrefix, JsonConvert.SerializeObject(approvedSubmissionEntities));

--- a/src/EPR.PRN.ObligationCalculation.Function/StoreApprovedSubmissionsFunction.cs
+++ b/src/EPR.PRN.ObligationCalculation.Function/StoreApprovedSubmissionsFunction.cs
@@ -16,23 +16,10 @@ public class StoreApprovedSubmissionsFunction(ILogger<StoreApprovedSubmissionsFu
         {
             logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: New session started", config.Value.LogPrefix);
 
-            var lastSuccessfulRunDate = string.Empty;
-            if (config.Value.UseDefaultRunDate)
-            {
-                lastSuccessfulRunDate = config.Value.DefaultRunDate;
-                logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Last run date {Date} used from configuration values", config.Value.LogPrefix, lastSuccessfulRunDate);
-            }
-            else
-            {
-                lastSuccessfulRunDate = await serviceBusProvider.GetLastSuccessfulRunDateFromQueue();
-                logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Last run date {Date} retrieved from queue", config.Value.LogPrefix, lastSuccessfulRunDate);
-            }
+            var lastSuccessfulRunDateFromQueue = await serviceBusProvider.GetLastSuccessfulRunDateFromQueue();
+            logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Last run date {Date} retrieved from queue", config.Value.LogPrefix, lastSuccessfulRunDateFromQueue);
 
-            if (string.IsNullOrEmpty(lastSuccessfulRunDate))
-            {
-                logger.LogError("{LogPrefix}: StoreApprovedSubmissionsFunction: Last succesful run date is empty and function is terminated", config.Value.LogPrefix);
-                return;
-            }
+            var lastSuccessfulRunDate = string.IsNullOrEmpty(lastSuccessfulRunDateFromQueue) ? config.Value.DefaultRunDate : lastSuccessfulRunDateFromQueue;
 
             var approvedSubmissionEntities = await submissionsService.GetApprovedSubmissionsData(lastSuccessfulRunDate);
             logger.LogInformation("{LogPrefix}: StoreApprovedSubmissionsFunction: Approved submission entities retrieved from backnend {ApprovedSubmissionEntities}", config.Value.LogPrefix, JsonConvert.SerializeObject(approvedSubmissionEntities));

--- a/src/EPR.PRN.ObligationCalculation.Function/settings.json
+++ b/src/EPR.PRN.ObligationCalculation.Function/settings.json
@@ -16,7 +16,6 @@
         "ServiceBus__LogPrefix": "[EPR.PRN.ObligationCalulation]",
         "ApplicationConfig__LogPrefix": "[EPR.PRN.ObligationCalulation]",
         "ApplicationConfig__DeveloperMode": false,
-        "ApplicationConfig__UseDefaultRunDate": "UseDevelopmentStorage=true",
         "ApplicationConfig__DefaultRunDate": "UseDevelopmentStorage=true",
         "StoreApprovedSubmissions__Schedule": "0 0 1 * * MON-FRI"
     }


### PR DESCRIPTION
- Removed UseDefaultRunDate flag
- Updated the StoredApprovedSubmissionsFunction to use DefaultRunDate only when no date available from lastSuccessfulRunDate queue.